### PR TITLE
workaround to remove combat taint issues

### DIFF
--- a/src/frame.lua
+++ b/src/frame.lua
@@ -367,11 +367,9 @@ do
 	f:SetScript("OnEvent", function()
 		if not InCombatLockdown() then
 			OpenAllBags()
-			CloseAllBags()
-			-- NOTE(Riotdog): The bag highlight persists despite the CloseAllBags() call.
-			-- It seems that we can't do it in the same frame. Disable the highlight on
-			-- the next possible frame.
-			C_Timer.After(0, function() Addon.Inventory:HighlightMainMenu(false) end)
+			-- NOTE(Riotdog): The bag highlight persists if we close the bags in the
+			-- same frame. Close all bags on the next possible frame instead.
+			C_Timer.After(0, function() CloseAllBags() end)
 			f:UnregisterAllEvents()
 		end
 	end)


### PR DESCRIPTION
How to replicate the tainted frame issue (that leads to addon action blocked errors):

1. Reload the UI with `/reload`.
2. Do *not* open your bags yet.
3. Enter combat.
4. Open your bags now.
5. Bagnon creates the inventory frame and item frames on demand on first open, now during combat, leading to tainted frames.
6. Attempting to use items in the inventory causes addon action blocked errors.

Snippet of the taint log:

```
1/3 22:59:46.868  Execution tainted by Bagnon while reading ToggleAllBags - OPENALLBAGS:1
1/3 22:59:46.895      CreateFrame()
1/3 22:59:46.895      Interface/AddOns/Bagnon/src/frame.lua:93 BagnonInventory1:Layout()
1/3 22:59:46.895      Interface/AddOns/Bagnon/src/frame.lua:63 BagnonInventory1:Update()
1/3 22:59:46.895      Interface/AddOns/Bagnon/src/frame.lua:53 BagnonInventory1:RegisterSignals()
1/3 22:59:46.895      Interface/AddOns/BagBrother/core/classes/frameBase.lua:21
1/3 22:59:46.895      Interface/AddOns/BagBrother/frames/containers/inventory.lua:26
1/3 22:59:46.895      BagnonInventory1:Show()
1/3 22:59:46.895      Interface/AddOns/BagBrother/core/api/frames.lua:32 Show()
1/3 22:59:46.895      Interface/AddOns/BagBrother/core/api/frames.lua:24
1/3 22:59:46.895      Interface/AddOns/BagBrother/core/features/autoDisplay.lua:83 ToggleAllBags()
1/3 22:59:46.895      OPENALLBAGS:1
```

This PR includes a workaround that forces the inventory frame and item frames to be created on login  (`PLAYER_ENTERING_WORLD`) before combat lockdown can happen. With this workaround, I have not been able to taint the inventory frame anymore - even when `/reload`-ing the UI mid-combat.

There's probably a more elegant way and/or better place to create the frames on startup, possibly in the `BagBrother` addon instead, but this change should be quite non-invasive (just calling hooked Blizzard APIs to open and close the bags on login).

Potentially fixes #1838, #1833, #1832, #1826 etc.