### PR TITLE
Fixed the bug regarding the ESC key is not working properly to close the frames

### DIFF
--- a/src/frame.lua
+++ b/src/frame.lua
@@ -34,6 +34,14 @@ function Frame:New(id)
 	f:SetScript('OnShow', self.OnShow)
 	f:SetScript('OnHide', self.OnHide)
 
+	--[[
+		This is not working properly since the name of the frame
+		always nil. I'm not sure how could you set it properly or
+		what's the actual problem
+		The interesting part is when both the bag and the bank is open,
+		it is closing but only the bag, though both name is still nil.
+		That's some sort of black magic.
+	]]
 	tinsert(UISpecialFrames, f:GetName())
 	return f
 end
@@ -44,6 +52,14 @@ function Frame:RegisterSignals()
 	self:RegisterSignal('SKINS_LOADED', 'UpdateBackdrop')
 	self:RegisterFrameSignal('BAG_FRAME_TOGGLED', 'Layout')
 	self:RegisterFrameSignal('ELEMENT_RESIZED', 'Layout')
+	self:SetScript('OnKeyDown', function(_, key)
+		if key == 'ESCAPE' or key == 27 then
+			self:SetPropagateKeyboardInput(false)
+			self:Hide()
+		else
+			self:SetPropagateKeyboardInput(true)
+		end
+	end)
 	self:Update()
 end
 


### PR DESCRIPTION
I left a comment as well in the code at this line:

`tinsert(UISpecialFrames, f:GetName())`

This is not working at all since the name of the frame is not being set (or not properly) the way the frame is being created right now.
To top it all, what other people described is that it's closing the main bag only when the bank is open, but not the bank nor in other situations.

I added the following to `RegisterSignals()`

```lua
self:SetScript('OnKeyDown', function(_, key)
		if key == 'ESCAPE' or key == 27 then
			self:SetPropagateKeyboardInput(false)
			self:Hide()
		else
			self:SetPropagateKeyboardInput(true)
		end
	end)
``` 

You need to use `self:SetPropagateKeyboardInput(true)` to allow
the key inputs when the bag is open otherwise it's not working with `SetScript()`

I tested it in/out of combat, and with the bank slots too. It works perfectly, though a more proper fix would be better I guess 🚀 

So now it looks like the following:

```lua
function Frame:RegisterSignals()
	self:RegisterSignal('UPDATE_ALL', 'Update')
	self:RegisterSignal('RULES_LOADED', 'FindRules')
	self:RegisterSignal('SKINS_LOADED', 'UpdateBackdrop')
	self:RegisterFrameSignal('BAG_FRAME_TOGGLED', 'Layout')
	self:RegisterFrameSignal('ELEMENT_RESIZED', 'Layout')
	self:SetScript('OnKeyDown', function(_, key)
		if key == 'ESCAPE' or key == 27 then
			self:SetPropagateKeyboardInput(false)
			self:Hide()
		else
			self:SetPropagateKeyboardInput(true)
		end
	end)
	self:Update()
end
``` 

You can add the same for the classic variations as well. I did not do so because I'm not playing them, and no time to test all of them either.